### PR TITLE
BUN-13416

### DIFF
--- a/src/Application/Actions/ActionBase.ts
+++ b/src/Application/Actions/ActionBase.ts
@@ -31,26 +31,8 @@ export abstract class ActionBase implements IAction {
     span.setTag(Tags.SPAN_KIND_MESSAGING_PRODUCER, true);
 
     return PromiseB.try(() => {
-      span.log({
-        event: "start",
-        value: {
-          action: this.getActionName(),
-        },
-      });
+      return this.doCall({ req, res, span });
     })
-      .then(() => {
-        return this.doCall({ req, res, span });
-      })
-      .then((result: any) => {
-        span.log({
-          event: "finish",
-          value: {
-            action: this.getActionName(),
-            result: result,
-          },
-        });
-        return result;
-      })
       .then((result: any) => {
         this.postDoCall({ res, result });
       })

--- a/src/Domain/Services/Task/ServiceTaskBase.ts
+++ b/src/Domain/Services/Task/ServiceTaskBase.ts
@@ -64,19 +64,7 @@ export abstract class ServiceTaskBase<T, Q> {
         this.span = span;
       })
       .then(() => {
-        this.span.log({
-          event: `start-${this.getCurrentTaskName()}`,
-          value: { result: this.message },
-        });
-      })
-      .then(() => {
         return this.task();
-      })
-      .then(() => {
-        this.span.log({
-          event: `finish-${this.getCurrentTaskName()}`,
-          value: { result: {} },
-        });
       })
       .then(() => {
         this.span.setTag(Tags.HTTP_STATUS_CODE, 200);
@@ -112,21 +100,10 @@ export abstract class ServiceTaskBase<T, Q> {
 
   protected task(): PromiseB<Q> {
     return PromiseB.try(() => {
-      this.span.log({
-        event: `start-${this.getCurrentTaskName()}-task`,
-        value: { result: {} },
-      });
-    })
-      .then(() => {
-        return this.doTask();
-      })
-      .then((result: Q) => {
-        this.span.log({
-          event: `finish-${this.getCurrentTaskName()}-task`,
-          value: { result: { result } },
-        });
-        return result;
-      });
+      return this.doTask();
+    }).then((result: Q) => {
+      return result;
+    });
   }
 
   protected abstract doTask(): PromiseB<Q>;

--- a/src/Infrastructure/Services/Http/HttpTracing.ts
+++ b/src/Infrastructure/Services/Http/HttpTracing.ts
@@ -48,17 +48,9 @@ export class HttpTracing implements HttpInterface {
       ...options.headers,
     };
     return PromiseB.try(() => {
-      span.log({
-        value: { options: options },
-      });
+      return this.adapter.get(options);
     })
-      .then(() => {
-        return this.adapter.get(options);
-      })
       .then((response: HttpResponse) => {
-        span.log({
-          value: { response: response.data },
-        });
         span.setTag(Tags.HTTP_STATUS_CODE, 200);
         span.finish();
         return response;
@@ -88,17 +80,9 @@ export class HttpTracing implements HttpInterface {
       ...options.headers,
     };
     return PromiseB.try(() => {
-      span.log({
-        value: { options: options },
-      });
+      return this.adapter.post(options);
     })
-      .then(() => {
-        return this.adapter.post(options);
-      })
       .then((response: HttpResponse) => {
-        span.log({
-          value: { response: response.data },
-        });
         span.setTag(Tags.HTTP_STATUS_CODE, response.status);
         span.finish();
         return response;


### PR DESCRIPTION
Fix endpoints CheckData & Summary, desacoplando el retorno de data de forma que devuelva data/metricas a nivel de organizacion aunque no existan posteos en el periodo. Removidos span.logs innecesarios.

Ticket:
https://bunker.atlassian.net/browse/BUN-13416

[DEPENDENCIES]
- https://github.com/BunkerDB/linkedin-ms/pull/6
- https://github.com/BunkerDB/linkedin-e/pull/6
- https://github.com/BunkerDB/linkedin-tl/pull/5